### PR TITLE
Allow hosting of custom ApplicationContext

### DIFF
--- a/src/WindowsFormsLifetime/WindowsFormsHostedService.cs
+++ b/src/WindowsFormsLifetime/WindowsFormsHostedService.cs
@@ -8,8 +8,7 @@ using System.Windows.Forms;
 
 namespace OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime
 {
-    public class WindowsFormsHostedService<TStartForm> : IHostedService, IDisposable
-        where TStartForm : Form
+    public class WindowsFormsHostedService : IHostedService, IDisposable
     {
         private CancellationTokenRegistration _applicationStoppingRegistration;
         private readonly WindowsFormsLifetimeOptions _options;
@@ -30,7 +29,7 @@ namespace OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime
         {
             _applicationStoppingRegistration = _hostApplicationLifetime.ApplicationStopping.Register(state =>
             {
-                ((WindowsFormsHostedService<TStartForm>)state).OnApplicationStopping();
+                ((WindowsFormsHostedService)state).OnApplicationStopping();
             },
             this);
 
@@ -56,18 +55,19 @@ namespace OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime
             Application.SetCompatibleTextRenderingDefault(_options.CompatibleTextRenderingDefault);
             Application.ApplicationExit += OnApplicationExit;
 
-            var form = _serviceProvider.GetService<TStartForm>();
+            var applicationContext = _serviceProvider.GetService<ApplicationContext>();
 
-            Application.Run(form);
+            Application.Run(applicationContext);
         }
 
         private void OnApplicationStopping()
         {
-            var form = _serviceProvider.GetService<TStartForm>();
+            var applicationContext = _serviceProvider.GetService<ApplicationContext>();
+            var form = applicationContext.MainForm;
 
             // If the form is closed then the handle no longer exists
             // We would get an exception trying to invoke from the control when it is already closed
-            if (form.IsHandleCreated)
+            if (form != null && form.IsHandleCreated)
             {
                 // If the host lifetime is stopped, gracefully close and dispose of forms in the service provider
                 form.Invoke(new Action(() =>

--- a/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
+++ b/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
@@ -1,23 +1,142 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using System.Windows.Forms;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime;
+using Timer = System.Windows.Forms.Timer;
 
 namespace WindowsFormsLifetimeTests
 {
-    public class WindowsFormsLifetimeTestss
+    public class WindowsFormsLifetimeTests
     {
-        public class Form1 : Form { }
+        public class TestForm : Form
+        {
+            protected override void SetVisibleCore(bool value)
+            {
+                // Don't flash window when running unit tests
+                base.SetVisibleCore(false);
+
+                if (!IsHandleCreated)
+                {
+                    CreateHandle();
+                    OnLoad(EventArgs.Empty);
+                }
+            }
+        }
+
+        public class TestContext : ApplicationContext
+        {
+            public TestContext(Action<TestContext> onStart = null)
+            {
+                // Let's invoke this after constructor has been run
+                var timer = new Timer { Interval = 1, Enabled = true };
+                timer.Tick += (sender, args) =>
+                {
+                    timer.Enabled = false;
+                    onStart?.Invoke(this);
+                };
+            }
+        }
 
         [Fact]
-        public void ServicesAreAvailable()
+        public void ServicesAreAvailableWhenUsingForm()
         {
-            using var host = new HostBuilder().UseWindowsFormsLifetime<Form1>().Build();
+            // given
+            var hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestForm>();
 
+            // when
+            using var host = hostBuilder.Build();
+
+            // then
             Assert.IsType<WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
-            Assert.IsType<WindowsFormsHostedService<Form1>>(host.Services.GetService<IHostedService>());
-            Assert.NotNull(host.Services.GetService<Form1>());
+            Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
+            Assert.NotNull(host.Services.GetService<ApplicationContext>());
+            Assert.NotNull(host.Services.GetService<TestForm>());
+        }
+
+        [Fact]
+        public void ServicesAreAvailableWhenUsingApplicationContext()
+        {
+            // given
+            var hostBuilder = new HostBuilder().UseWindowsFormsLifetimeAppContext<TestContext>();
+
+            // when
+            using var host = hostBuilder.Build();
+
+            // then
+            Assert.IsType<WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
+            Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
+            Assert.NotNull(host.Services.GetService<ApplicationContext>());
+            Assert.NotNull(host.Services.GetService<TestContext>());
+        }
+
+        [Fact]
+        public async Task ShouldRunAndCloseForm()
+        {
+            // given
+            using var host = new HostBuilder().UseWindowsFormsLifetime<TestForm>().Build();
+
+            var form = host.Services.GetService<TestForm>();
+            form.Load += (sender, args) => form.Invoke(new Action(Application.Exit));
+
+            // when
+            await host.RunAsync();
+
+            // then
+            // if we are here, nothing has failed
+        }
+
+        [Fact]
+        public async Task ShouldRunAndCloseFormWhenCancelling()
+        {
+            // given
+            using var host = new HostBuilder().UseWindowsFormsLifetime<TestForm>().Build();
+            using var cancelToken = new CancellationTokenSource();
+
+            var form = host.Services.GetService<TestForm>();
+            form.Load += (sender, args) => cancelToken.Cancel();
+
+            // when
+            await host.RunAsync(cancelToken.Token);
+
+            // then
+            // if we are here, nothing has failed
+        }
+
+        [Fact]
+        public async Task ShouldRunAndCloseApplicationContext()
+        {
+            // given
+            using var host = new HostBuilder()
+                .UseWindowsFormsLifetimeAppContext<TestContext>()
+                .ConfigureServices(services => services.AddSingleton<Action<TestContext>>(context => Application.Exit()))
+                .Build();
+
+            // when
+            await host.RunAsync();
+
+            // then
+            // if we are here, nothing has failed
+        }
+
+        [Fact]
+        public async Task ShouldRunAndCloseApplicationContextWhenCancelling()
+        {
+            // given
+            using var cancelToken = new CancellationTokenSource();
+            using var host = new HostBuilder()
+                .UseWindowsFormsLifetimeAppContext<TestContext>()
+                .ConfigureServices(services => services.AddSingleton<Action<TestContext>>(_ => cancelToken.Cancel()))
+                .Build();
+
+            // when
+            await host.RunAsync(cancelToken.Token);
+
+            // then
+            // if we are here, nothing has failed
         }
     }
 }


### PR DESCRIPTION
Sometimes it is necessary to use `Application.Run(new MyApplicationContext(new Form1))`, this PR adds this feature in form of `UseWindowsFormsLifetimeAppContext<TAppContext>`

Also added more unit test.