### PR TITLE
Enable Minimal API support without the Web SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,30 +63,15 @@ namespace WinFormsApp1
 
 ### Use the Minimal API
 
-Change the projects sdk to `Microsoft.NET.Sdk.Web` so we can use the `WebApplication` class.
-
-Add `NoDefaultLaunchSettingsFile` to the `csproj` so a `launchSettings.json` file isn't created automatically for us.
-
-```xml
-<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <UseWindowsForms>true</UseWindowsForms>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
-    </PropertyGroup>
-</Project>
-```
-
 Replace the contents of `Program.cs` with the following.
 
 ```csharp
+using Microsoft.Extensions.Hosting;
 using WinFormsApp1;
+using WindowsFormsLifetime;
 
-var builder = WebApplication.CreateBuilder(args);
-builder.Host.UseWindowsFormsLifetime<Form1>();
+var builder = WebApplication.CreateApplicationBuilder(args);
+builder.UseWindowsFormsLifetime<Form1>();
 var app = builder.Build();
 app.Run();
 ```

--- a/samples/SampleApp/Form1.cs
+++ b/samples/SampleApp/Form1.cs
@@ -1,4 +1,5 @@
-﻿using WindowsFormsLifetime;
+﻿using Microsoft.Extensions.Logging;
+using WindowsFormsLifetime;
 
 namespace SampleApp;
 

--- a/samples/SampleApp/Form2.cs
+++ b/samples/SampleApp/Form2.cs
@@ -1,4 +1,5 @@
-﻿using WindowsFormsLifetime;
+﻿using Microsoft.Extensions.Logging;
+using WindowsFormsLifetime;
 
 namespace SampleApp;
 

--- a/samples/SampleApp/FormSpawnHostedService.cs
+++ b/samples/SampleApp/FormSpawnHostedService.cs
@@ -1,4 +1,6 @@
-﻿using WindowsFormsLifetime;
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using WindowsFormsLifetime;
 
 namespace SampleApp;
 

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -1,8 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using SampleApp;
 using WindowsFormsLifetime;
 
-var builder = WebApplication.CreateBuilder(args);
-builder.Host.UseWindowsFormsLifetime<Form1>();
+var builder = Host.CreateApplicationBuilder(args);
+builder.UseWindowsFormsLifetime<Form1>();
 builder.Services.AddHostedService<FormSpawnHostedService>();
 builder.Services.AddHostedService<TickingHostedService>();
 builder.Services.AddTransient<Form2>();

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net7.0-windows</TargetFramework>
@@ -6,7 +6,6 @@
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/samples/SampleApp/TickingHostedService.cs
+++ b/samples/SampleApp/TickingHostedService.cs
@@ -1,4 +1,7 @@
-﻿namespace SampleApp;
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SampleApp;
 
 public class TickingHostedService : BackgroundService
 {

--- a/src/WindowsFormsLifetime/HostBuilderExtensions.cs
+++ b/src/WindowsFormsLifetime/HostBuilderExtensions.cs
@@ -42,4 +42,112 @@ public static class HostBuilderExtensions
         where TAppContext : ApplicationContext
         where TStartForm : Form
         => hostBuilder.ConfigureServices(services => services.AddWindowsFormsLifetime(applicationContextFactory, configure));
+#if NET7_0_OR_GREATER
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="Form"/>,
+    /// then waits for the startup form to close before shutting down.
+    /// </summary>
+    /// <param name="hostAppBuilder">The <see cref="HostApplicationBuilder" /> to configure.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="HostApplicationBuilder"/> for chaining.</returns>
+    public static HostApplicationBuilder UseWindowsFormsLifetime<TStartForm>(
+        this HostApplicationBuilder hostAppBuilder, Action<WindowsFormsLifetimeOptions> configure = null)
+        where TStartForm : Form
+    {
+        hostAppBuilder.Services.AddWindowsFormsLifetime<TStartForm>(configure);
+
+        return hostAppBuilder;
+    }
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
+    /// then waits for the startup context to close before shutting down.
+    /// </summary>
+    /// <param name="hostAppBuilder">The <see cref="HostApplicationBuilder" /> to configure.</param>
+    /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="HostApplicationBuilder"/> for chaining.</returns>
+    public static HostApplicationBuilder UseWindowsFormsLifetime<TAppContext>(
+        this HostApplicationBuilder hostAppBuilder, Func<TAppContext> applicationContextFactory = null, Action<WindowsFormsLifetimeOptions> configure = null)
+        where TAppContext : ApplicationContext
+    {
+        hostAppBuilder.Services.AddWindowsFormsLifetime(applicationContextFactory, configure);
+
+        return hostAppBuilder;
+    }
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
+    /// then waits for the startup context to close before shutting down.
+    /// </summary>
+    /// <param name="hostAppBuilder">The <see cref="HostApplicationBuilder" /> to configure.</param>
+    /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="HostApplicationBuilder"/> for chaining.</returns>
+    public static HostApplicationBuilder UseWindowsFormsLifetime<TAppContext, TStartForm>(
+        this HostApplicationBuilder hostAppBuilder
+        , Func<TStartForm, TAppContext> applicationContextFactory, Action<WindowsFormsLifetimeOptions> configure = null)
+        where TAppContext : ApplicationContext
+        where TStartForm : Form
+    {
+        hostAppBuilder.Services.AddWindowsFormsLifetime(applicationContextFactory, configure);
+
+        return hostAppBuilder;
+    }
+#endif
+#if NET8_0_OR_GREATER
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="Form"/>,
+    /// then waits for the startup form to close before shutting down.
+    /// </summary>
+    /// <param name="hostAppBuilder">The <see cref="IHostApplicationBuilder" /> to configure.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="IHostApplicationBuilder"/> for chaining.</returns>
+    public static IHostApplicationBuilder UseWindowsFormsLifetime<TStartForm>(
+        this IHostApplicationBuilder hostAppBuilder, Action<WindowsFormsLifetimeOptions> configure = null)
+        where TStartForm : Form
+    {
+        hostAppBuilder.Services.AddWindowsFormsLifetime<TStartForm>(configure);
+
+        return hostAppBuilder;
+    }
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
+    /// then waits for the startup context to close before shutting down.
+    /// </summary>
+    /// <param name="hostAppBuilder">The <see cref="IHostApplicationBuilder" /> to configure.</param>
+    /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="IHostApplicationBuilder"/> for chaining.</returns>
+    public static IHostApplicationBuilder UseWindowsFormsLifetime<TAppContext>(
+        this IHostApplicationBuilder hostAppBuilder, Func<TAppContext> applicationContextFactory = null, Action<WindowsFormsLifetimeOptions> configure = null)
+        where TAppContext : ApplicationContext
+    {
+        hostAppBuilder.Services.AddWindowsFormsLifetime(applicationContextFactory, configure);
+
+        return hostAppBuilder;
+    }
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
+    /// then waits for the startup context to close before shutting down.
+    /// </summary>
+    /// <param name="hostAppBuilder">The <see cref="IHostApplicationBuilder" /> to configure.</param>
+    /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="IHostApplicationBuilder"/> for chaining.</returns>
+    public static IHostApplicationBuilder UseWindowsFormsLifetime<TAppContext, TStartForm>(
+        this IHostApplicationBuilder hostAppBuilder
+        , Func<TStartForm, TAppContext> applicationContextFactory, Action<WindowsFormsLifetimeOptions> configure = null)
+        where TAppContext : ApplicationContext
+        where TStartForm : Form
+    {
+        hostAppBuilder.Services.AddWindowsFormsLifetime(applicationContextFactory, configure);
+
+        return hostAppBuilder;
+    }
+#endif
 }

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net7.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
@@ -33,11 +33,22 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net7.0-windows'">
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds UseWindowsFormsLifetime extension methods to HostApplicationBuilder. Also avoids referencing Microsoft.Extensions.Hosting 7.0 when targeting .NET 6.0.