### PR TITLE
ApplicationContext object that accepts an IServiceProvider

### DIFF
--- a/src/WindowsFormsLifetime/HostBuilderExtensions.cs
+++ b/src/WindowsFormsLifetime/HostBuilderExtensions.cs
@@ -37,6 +37,21 @@ public static class HostBuilderExtensions
     /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
     /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
     /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
+    public static IHostBuilder UseWindowsFormsLifetime<TAppContext>(
+        this IHostBuilder hostBuilder,
+        Func<IServiceProvider, TAppContext> applicationContextFactory,
+        Action<WindowsFormsLifetimeOptions> configure = null)
+        where TAppContext : ApplicationContext
+        => hostBuilder.ConfigureServices(services => services.AddWindowsFormsLifetime(applicationContextFactory, configure));
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
+    /// then waits for the startup context to close before shutting down.
+    /// </summary>
+    /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
+    /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
     public static IHostBuilder UseWindowsFormsLifetime<TAppContext, TStartForm>(
         this IHostBuilder hostBuilder, Func<TStartForm, TAppContext> applicationContextFactory, Action<WindowsFormsLifetimeOptions> configure = null)
         where TAppContext : ApplicationContext
@@ -69,6 +84,27 @@ public static class HostBuilderExtensions
     /// <returns>The same instance of the <see cref="IHostApplicationBuilder"/> for chaining.</returns>
     public static IHostApplicationBuilder UseWindowsFormsLifetime<TAppContext>(
         this IHostApplicationBuilder hostAppBuilder, Func<TAppContext> applicationContextFactory = null, Action<WindowsFormsLifetimeOptions> configure = null)
+        where TAppContext : ApplicationContext
+    {
+        hostAppBuilder.Services.AddWindowsFormsLifetime(applicationContextFactory, configure);
+
+        return hostAppBuilder;
+    }
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the starup <see cref="ApplicationContext"/>,
+    /// then waits for the startup context to close before shutting down.
+    /// </summary>
+    /// <typeparam name="TAppContext">The type of <see cref="ApplicationContext"/> to manage.</typeparam>
+    /// <param name="hostAppBuilder">The <see cref="IHostApplicationBuilder" /> to configure.</param>
+    /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <returns>The same instance of the <see cref="IHostApplicationBuilder"/> for chaining.</returns>
+    /// <returns></returns>
+    public static IHostApplicationBuilder UseWindowsFormsLifetime<TAppContext>(
+        this IHostApplicationBuilder hostAppBuilder,
+        Func<IServiceProvider, TAppContext> applicationContextFactory,
+        Action<WindowsFormsLifetimeOptions> configure = null)
         where TAppContext : ApplicationContext
     {
         hostAppBuilder.Services.AddWindowsFormsLifetime(applicationContextFactory, configure);

--- a/src/WindowsFormsLifetime/HostBuilderExtensions.cs
+++ b/src/WindowsFormsLifetime/HostBuilderExtensions.cs
@@ -5,7 +5,7 @@ namespace WindowsFormsLifetime;
 public static class HostBuilderExtensions
 {
     /// <summary>
-    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="Form"/>, 
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="Form"/>,
     /// then waits for the startup form to close before shutting down.
     /// </summary>
     /// <typeparam name="TStartForm">The type of the startup form.</typeparam>
@@ -103,7 +103,7 @@ public static class HostBuilderExtensions
     }
 
     /// <summary>
-    /// Enables Windows Forms support, builds and starts the host, starts the starup <see cref="ApplicationContext"/>,
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
     /// then waits for the startup context to close before shutting down.
     /// </summary>
     /// <typeparam name="TAppContext">The type of <see cref="ApplicationContext"/> to manage.</typeparam>
@@ -111,7 +111,6 @@ public static class HostBuilderExtensions
     /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
     /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
     /// <returns>The same instance of the <see cref="IHostApplicationBuilder"/> for chaining.</returns>
-    /// <returns></returns>
     public static IHostApplicationBuilder UseWindowsFormsLifetime<TAppContext>(
         this IHostApplicationBuilder hostAppBuilder,
         Func<IServiceProvider, TAppContext> applicationContextFactory,

--- a/src/WindowsFormsLifetime/HostBuilderExtensions.cs
+++ b/src/WindowsFormsLifetime/HostBuilderExtensions.cs
@@ -5,6 +5,17 @@ namespace WindowsFormsLifetime;
 public static class HostBuilderExtensions
 {
     /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="Form"/>, 
+    /// then waits for the startup form to close before shutting down.
+    /// </summary>
+    /// <typeparam name="TStartForm">The type of the startup form.</typeparam>
+    /// <param name="hostBuilder">The <see cref="IHostBuilder" /> to configure.</param>
+    /// <returns>The same instance of the <see cref="IHostBuilder"/> for chaining.</returns>
+    public static IHostBuilder UseWindowsFormsLifetime<TStartForm>(this IHostBuilder hostBuilder)
+        where TStartForm : Form
+        => hostBuilder.ConfigureServices(services => services.AddWindowsFormsLifetime<TStartForm>((Action<WindowsFormsLifetimeOptions>)null));
+
+    /// <summary>
     /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="Form"/>,
     /// then waits for the startup form to close before shutting down.
     /// </summary>

--- a/src/WindowsFormsLifetime/ServiceCollectionExtensions.cs
+++ b/src/WindowsFormsLifetime/ServiceCollectionExtensions.cs
@@ -62,7 +62,7 @@ public static class ServiceCollectionExtensions
             ? services.AddSingleton<TAppContext>()
             : services.AddSingleton<TAppContext>(provider => applicationContextFactory());
 
-        services.AddSingleton<ApplicationContext, TAppContext>();
+        services.AddSingleton<ApplicationContext>(provider => provider.GetRequiredService<TAppContext>());
         services.AddWindowsFormsLifetime(configure, preApplicationRunAction);
 
         return services;
@@ -80,7 +80,7 @@ public static class ServiceCollectionExtensions
     /// <returns>The same instance of the <see cref="IServiceCollection"/> for chaining.</returns>
     public static IServiceCollection AddWindowsFormsLifetime<TAppContext>(
         this IServiceCollection services,
-        Func<IServiceProvider, TAppContext> applicationContextFactory = null,
+        Func<IServiceProvider, TAppContext> applicationContextFactory,
         Action<WindowsFormsLifetimeOptions> configure = null,
         Action<IServiceProvider> preApplicationRunAction = null)
         where TAppContext : ApplicationContext
@@ -90,7 +90,7 @@ public static class ServiceCollectionExtensions
             : services.AddSingleton<TAppContext>(provider => applicationContextFactory(provider));
 
         services
-            .AddSingleton<ApplicationContext, TAppContext>()
+            .AddSingleton<ApplicationContext>(provider => provider.GetRequiredService<TAppContext>())
             .AddWindowsFormsLifetime(configure, preApplicationRunAction);
 
         return services;
@@ -116,7 +116,7 @@ public static class ServiceCollectionExtensions
             var startForm = provider.GetRequiredService<TStartForm>();
             return applicationContextFactory(startForm);
         });
-        services.AddSingleton<ApplicationContext, TAppContext>();
+        services.AddSingleton<ApplicationContext>(provider => provider.GetRequiredService<TAppContext>());
         services.AddWindowsFormsLifetime(configure, preApplicationRunAction);
 
         return services;

--- a/src/WindowsFormsLifetime/ServiceCollectionExtensions.cs
+++ b/src/WindowsFormsLifetime/ServiceCollectionExtensions.cs
@@ -72,6 +72,34 @@ public static class ServiceCollectionExtensions
     /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
     /// then waits for the startup context to close before shutting down.
     /// </summary>
+    /// <typeparam name="TAppContext">The type of <see cref="ApplicationContext"/> to manage.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add the required services to.</param>
+    /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
+    /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>
+    /// <param name="preApplicationRunAction">The delegate to execute before the application starts running.</param>
+    /// <returns>The same instance of the <see cref="IServiceCollection"/> for chaining.</returns>
+    public static IServiceCollection AddWindowsFormsLifetime<TAppContext>(
+        this IServiceCollection services,
+        Func<IServiceProvider, TAppContext> applicationContextFactory = null,
+        Action<WindowsFormsLifetimeOptions> configure = null,
+        Action<IServiceProvider> preApplicationRunAction = null)
+        where TAppContext : ApplicationContext
+    {
+        services = applicationContextFactory is null
+            ? services.AddSingleton<TAppContext>()
+            : services.AddSingleton<TAppContext>(provider => applicationContextFactory(provider));
+
+        services
+            .AddSingleton<ApplicationContext, TAppContext>()
+            .AddWindowsFormsLifetime(configure, preApplicationRunAction);
+
+        return services;
+    }
+
+    /// <summary>
+    /// Enables Windows Forms support, builds and starts the host, starts the startup <see cref="ApplicationContext"/>,
+    /// then waits for the startup context to close before shutting down.
+    /// </summary>
     /// <param name="services">The <see cref="IServiceCollection" /> to add the required services to.</param>
     /// <param name="applicationContextFactory">The <see cref="ApplicationContext"/> factory.</param>
     /// <param name="configure">The delegate for configuring the <see cref="WindowsFormsLifetimeOptions"/>.</param>

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -5,7 +5,7 @@
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
-		<Version>1.2.1-beta.2</Version>
+		<Version>1.2.0</Version>
 		<Authors>Alex Oswald</Authors>
 		<Company>Oswald Technologies, LLC</Company>
 		<Description>.NET Core hosting infrastructure for Windows Forms.</Description>

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -5,7 +5,7 @@
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
-		<Version>1.2.0</Version>
+		<Version>1.2.1-beta.1</Version>
 		<Authors>Alex Oswald</Authors>
 		<Company>Oswald Technologies, LLC</Company>
 		<Description>.NET Core hosting infrastructure for Windows Forms.</Description>

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -5,7 +5,7 @@
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
-		<Version>1.2.1-beta.1</Version>
+		<Version>1.2.1-beta.2</Version>
 		<Authors>Alex Oswald</Authors>
 		<Company>Oswald Technologies, LLC</Company>
 		<Description>.NET Core hosting infrastructure for Windows Forms.</Description>
@@ -25,6 +25,7 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<NoWarn>CS1591</NoWarn>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -25,7 +25,7 @@
 		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<NoWarn>CS1591</NoWarn>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
+++ b/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
@@ -86,6 +86,21 @@ public class WindowsFormsLifetimeTests
     }
 
     [Fact]
+    public void Services_Available_With_ApplicationContext_With_ServiceProvider()
+    {
+        var hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestContext>(static provider => new());
+
+        using var host = hostBuilder.Build();
+
+        Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
+        Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
+        Assert.NotNull(host.Services.GetService<ApplicationContext>());
+        Assert.NotNull(host.Services.GetService<TestContext>());
+        Assert.NotNull(host.Services.GetService<IFormProvider>());
+        Assert.Null(host.Services.GetService<TestForm>());
+    }
+
+    [Fact]
     public async Task Should_Run_And_Close_Form()
     {
         using var host = new HostBuilder().UseWindowsFormsLifetime<TestForm>().Build();

--- a/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
+++ b/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
@@ -41,6 +41,20 @@ public class WindowsFormsLifetimeTests
         }
     }
 
+    private sealed class TestDependency
+    {
+    }
+
+    private sealed class ServiceProviderTestContext : ApplicationContext
+    {
+        public ServiceProviderTestContext(TestDependency dependency)
+        {
+            Dependency = dependency;
+        }
+
+        public TestDependency Dependency { get; }
+    }
+
     [Fact]
     public void Services_Available_With_Form()
     {
@@ -64,8 +78,10 @@ public class WindowsFormsLifetimeTests
 
         Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
         Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
-        Assert.NotNull(host.Services.GetService<ApplicationContext>());
-        Assert.NotNull(host.Services.GetService<TestContext>());
+        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        var testContext = host.Services.GetRequiredService<TestContext>();
+
+        Assert.Same(testContext, applicationContext);
         Assert.NotNull(host.Services.GetService<IFormProvider>());
         Assert.Null(host.Services.GetService<TestForm>());
     }
@@ -79,8 +95,10 @@ public class WindowsFormsLifetimeTests
 
         Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
         Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
-        Assert.NotNull(host.Services.GetService<ApplicationContext>());
-        Assert.NotNull(host.Services.GetService<TestContext>());
+        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        var testContext = host.Services.GetRequiredService<TestContext>();
+
+        Assert.Same(testContext, applicationContext);
         Assert.NotNull(host.Services.GetService<TestForm>());
         Assert.NotNull(host.Services.GetService<IFormProvider>());
     }
@@ -88,16 +106,58 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public void Services_Available_With_ApplicationContext_With_ServiceProvider()
     {
-        var hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestContext>(static provider => new());
+        var dependency = new TestDependency();
+        var hostBuilder = new HostBuilder()
+            .ConfigureServices(services => services.AddSingleton<TestDependency>(dependency))
+            .UseWindowsFormsLifetime<ServiceProviderTestContext>(
+                static provider => new(provider.GetRequiredService<TestDependency>()));
 
         using var host = hostBuilder.Build();
 
         Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
         Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
-        Assert.NotNull(host.Services.GetService<ApplicationContext>());
-        Assert.NotNull(host.Services.GetService<TestContext>());
+        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        var testContext = host.Services.GetRequiredService<ServiceProviderTestContext>();
+
+        Assert.Same(testContext, applicationContext);
+        Assert.Same(dependency, testContext.Dependency);
         Assert.NotNull(host.Services.GetService<IFormProvider>());
         Assert.Null(host.Services.GetService<TestForm>());
+    }
+
+    [Fact]
+    public void Services_Available_With_ApplicationContext_With_ServiceProvider_On_HostApplicationBuilder()
+    {
+        var dependency = new TestDependency();
+        var hostBuilder = Host.CreateApplicationBuilder();
+        hostBuilder.Services.AddSingleton<TestDependency>(dependency);
+
+        var returnedBuilder = hostBuilder.UseWindowsFormsLifetime<ServiceProviderTestContext>(
+            static provider => new(provider.GetRequiredService<TestDependency>()));
+
+        Assert.Same(hostBuilder, returnedBuilder);
+
+        using var host = hostBuilder.Build();
+
+        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        var testContext = host.Services.GetRequiredService<ServiceProviderTestContext>();
+
+        Assert.Same(testContext, applicationContext);
+        Assert.Same(dependency, testContext.Dependency);
+    }
+
+    [Fact]
+    public void Services_Available_With_ApplicationContext_Without_Factory_From_ServiceCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddWindowsFormsLifetime<TestContext>();
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var applicationContext = serviceProvider.GetRequiredService<ApplicationContext>();
+        var testContext = serviceProvider.GetRequiredService<TestContext>();
+
+        Assert.Same(testContext, applicationContext);
     }
 
     [Fact]


### PR DESCRIPTION
Added support for an ApplicationContext object that accepts an IServiceProvider.
Added tests for HostBuilder extension method. ServicesCollection extension method is tested implicitly.

Allows a Form to be managed by a Presenter class.