### PR TITLE
Create form with up to eight constructor parameters

### DIFF
--- a/src/WindowsFormsLifetime/FormProvider.cs
+++ b/src/WindowsFormsLifetime/FormProvider.cs
@@ -19,62 +19,44 @@ public class FormProvider : IFormProvider
         _serviceScopeFactory = serviceScopeFactory;
     }
 
-    public async Task<T> GetFormAsync<T>()
+    public Task<T> GetFormAsync<T>()
         where T : Form
-    {
-        // We are throttling this because there is only one gui thread
-        await _semaphore.WaitAsync();
-
-        var form = await _syncContextManager.SynchronizationContext.InvokeAsync(GetForm<T>);
-
-        _semaphore.Release();
-
-        return form;
-    }
+        => InvokeOnUiThreadAsync(GetForm<T>);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1>(T1 param1) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1);
+    public Task<TForm> GetFormAsync<TForm, T1>(T1 param1) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1, T2>(T1 param1, T2 param2) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1, param2);
+    public Task<TForm> GetFormAsync<TForm, T1, T2>(T1 param1, T2 param2) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1, param2);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3>(T1 param1, T2 param2, T3 param3) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3);
+    public Task<TForm> GetFormAsync<TForm, T1, T2, T3>(T1 param1, T2 param2, T3 param3) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1, param2, param3);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4>(T1 param1, T2 param2, T3 param3, T4 param4) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4);
+    public Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4>(T1 param1, T2 param2, T3 param3, T4 param4) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5);
+    public Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6);
+    public Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7);
+    public Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7);
 
     /// <inheritdoc />
-    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7, T8>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8) where TForm : Form
-        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7, param8);
+    public Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7, T8>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8) where TForm : Form
+        => CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7, param8);
 
-    public async Task<T> GetFormAsync<T>(IServiceScope scope) where T : Form
-    {
-        // We are throttling this because there is only one gui thread
-        await _semaphore.WaitAsync();
-
-        var form = await _syncContextManager.SynchronizationContext.InvokeAsync(() => scope.ServiceProvider.GetService<T>());
-
-        _semaphore.Release();
-
-        return form;
-    }
+    public Task<T> GetFormAsync<T>(IServiceScope scope) where T : Form
+        => InvokeOnUiThreadAsync(() => scope.ServiceProvider.GetService<T>());
 
     public Task<Form> GetMainFormAsync()
     {
@@ -84,6 +66,8 @@ public class FormProvider : IFormProvider
 
     public T GetForm<T>() where T : Form
     {
+        EnsureUiThread();
+
         T form = null;
         var scope = _serviceScopeFactory.CreateScope();
         try
@@ -140,12 +124,16 @@ public class FormProvider : IFormProvider
         => CreateFormWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7, param8);
 
     public T GetForm<T>(IServiceScope scope) where T : Form
-        => scope.ServiceProvider.GetService<T>();
+    {
+        EnsureUiThread();
+        return scope.ServiceProvider.GetService<T>();
+    }
 
     public void Dispose() => _semaphore?.Dispose();
 
     private TForm CreateFormWithParameters<TForm>(params object[] parameters) where TForm : Form
     {
+        EnsureUiThread();
         return CreateFormWithScope(scope => ActivatorUtilities.CreateInstance<TForm>(scope.ServiceProvider, parameters));
     }
 
@@ -174,19 +162,34 @@ public class FormProvider : IFormProvider
         return form;
     }
 
-    private async Task<TForm> CreateFormAsyncWithParameters<TForm>(params object[] parameters) where TForm : Form
+    private Task<TForm> CreateFormAsyncWithParameters<TForm>(params object[] parameters) where TForm : Form
+        => InvokeOnUiThreadAsync(() => CreateFormWithParameters<TForm>(parameters));
+
+    private async Task<T> InvokeOnUiThreadAsync<T>(Func<T> formFactory)
     {
+        var synchronizationContext = GetUiSynchronizationContext();
         await _semaphore.WaitAsync();
 
         try
         {
-            var form = await _syncContextManager.SynchronizationContext.InvokeAsync(() =>
-                CreateFormWithParameters<TForm>(parameters));
-            return form;
+            return await synchronizationContext.InvokeAsync(formFactory);
         }
         finally
         {
             _semaphore.Release();
         }
     }
+
+    private void EnsureUiThread()
+    {
+        var synchronizationContext = GetUiSynchronizationContext();
+        if (!ReferenceEquals(SynchronizationContext.Current, synchronizationContext))
+        {
+            throw new InvalidOperationException("Synchronous form creation must be called on the Windows Forms UI thread.");
+        }
+    }
+
+    private WindowsFormsSynchronizationContext GetUiSynchronizationContext()
+        => _syncContextManager.SynchronizationContext
+            ?? throw new InvalidOperationException("The Windows Forms UI thread is not available.");
 }

--- a/src/WindowsFormsLifetime/FormProvider.cs
+++ b/src/WindowsFormsLifetime/FormProvider.cs
@@ -1,41 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace WindowsFormsLifetime;
-
-public interface IFormProvider
-{
-    /// <summary>
-    /// Gets the requested form type and ensures it is created on the UI thread.
-    /// </summary>
-    /// <typeparam name="T">The form type to get.</typeparam>
-    /// <returns>An instance of the form, asynchronously.</returns>
-    Task<T> GetFormAsync<T>() where T : Form;
-
-    /// <summary>
-    /// Gets the requested form type and ensures it is created on the UI thread. Creates the form in the given scope.
-    /// </summary>
-    /// <typeparam name="T">The form type to get.</typeparam>
-    /// <param name="scope">The scope in which the form should be created.</param>
-    /// <returns>An instance of the form, asynchronously.</returns>
-    Task<T> GetFormAsync<T>(IServiceScope scope) where T : Form;
-
-    Task<Form> GetMainFormAsync();
-
-    /// <summary>
-    /// Gets the requested form type on the current thread. Should only be called on the UI thread. All scoped and transient dependencies will be disposed when the form is disposed.
-    /// </summary>
-    /// <typeparam name="T">The form type to get.</typeparam>
-    /// <returns>An instance of the form.</returns>
-    T GetForm<T>() where T : Form;
-
-    /// <summary>
-    /// Gets the requested form type on the current thread. Should only be called on the UI thread.  Creates the form in the given scope.
-    /// </summary>
-    /// <typeparam name="T">The form type to get.</typeparam>
-    /// <param name="scope">The scope in which the form should be created.</param>
-    /// <returns>An instance of the form.</returns>
-    T GetForm<T>(IServiceScope scope) where T : Form;
-}
 
 public class FormProvider : IFormProvider
 {
@@ -66,6 +31,38 @@ public class FormProvider : IFormProvider
 
         return form;
     }
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1>(T1 param1) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1);
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1, T2>(T1 param1, T2 param2) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1, param2);
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3>(T1 param1, T2 param2, T3 param3) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3);
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4>(T1 param1, T2 param2, T3 param3, T4 param4) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4);
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5);
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6);
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7);
+
+    /// <inheritdoc />
+    public async Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7, T8>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8) where TForm : Form
+        => await CreateFormAsyncWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7, param8);
 
     public async Task<T> GetFormAsync<T>(IServiceScope scope) where T : Form
     {
@@ -110,8 +107,86 @@ public class FormProvider : IFormProvider
         return form;
     }
 
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1>(T1 param1) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1);
+
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1, T2>(T1 param1, T2 param2) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1, param2);
+
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1, T2, T3>(T1 param1, T2 param2, T3 param3) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1, param2, param3);
+
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1, T2, T3, T4>(T1 param1, T2 param2, T3 param3, T4 param4) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1, param2, param3, param4);
+
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1, T2, T3, T4, T5>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1, param2, param3, param4, param5);
+
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1, T2, T3, T4, T5, T6>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1, param2, param3, param4, param5, param6);
+
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1, T2, T3, T4, T5, T6, T7>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7);
+
+    /// <inheritdoc />
+    public TForm GetForm<TForm, T1, T2, T3, T4, T5, T6, T7, T8>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8) where TForm : Form
+        => CreateFormWithParameters<TForm>(param1, param2, param3, param4, param5, param6, param7, param8);
+
     public T GetForm<T>(IServiceScope scope) where T : Form
         => scope.ServiceProvider.GetService<T>();
 
     public void Dispose() => _semaphore?.Dispose();
+
+    private TForm CreateFormWithParameters<TForm>(params object[] parameters) where TForm : Form
+    {
+        return CreateFormWithScope(scope => ActivatorUtilities.CreateInstance<TForm>(scope.ServiceProvider, parameters));
+    }
+
+    private TForm CreateFormWithScope<TForm>(Func<IServiceScope, TForm> formFactory) where TForm : Form
+    {
+        TForm form;
+        var scope = _serviceScopeFactory.CreateScope();
+        try
+        {
+            form = formFactory(scope);
+            if (form == null)
+            {
+                scope.Dispose();
+            }
+            else
+            {
+                form.Disposed += (_, _) => scope.Dispose();
+            }
+        }
+        catch
+        {
+            scope.Dispose();
+            throw;
+        }
+
+        return form;
+    }
+
+    private async Task<TForm> CreateFormAsyncWithParameters<TForm>(params object[] parameters) where TForm : Form
+    {
+        await _semaphore.WaitAsync();
+
+        try
+        {
+            var form = await _syncContextManager.SynchronizationContext.InvokeAsync(() =>
+                CreateFormWithParameters<TForm>(parameters));
+            return form;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
 }

--- a/src/WindowsFormsLifetime/IFormProvider.cs
+++ b/src/WindowsFormsLifetime/IFormProvider.cs
@@ -210,6 +210,9 @@ public interface IFormProvider
     /// </summary>
     /// <typeparam name="T">The form type to get.</typeparam>
     /// <returns>An instance of the form.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the UI thread is not available.
+    /// </exception>
     T GetForm<T>() where T : Form;
 
     /// <summary>
@@ -426,5 +429,8 @@ public interface IFormProvider
     /// <typeparam name="T">The form type to get.</typeparam>
     /// <param name="scope">The scope in which the form should be created.</param>
     /// <returns>An instance of the form.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the UI thread is not available.
+    /// </exception>
     T GetForm<T>(IServiceScope scope) where T : Form;
 }

--- a/src/WindowsFormsLifetime/IFormProvider.cs
+++ b/src/WindowsFormsLifetime/IFormProvider.cs
@@ -1,0 +1,430 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace WindowsFormsLifetime;
+
+public interface IFormProvider
+{
+    /// <summary>
+    /// Gets the requested form type and ensures it is created on the UI thread.
+    /// </summary>
+    /// <typeparam name="T">The form type to get.</typeparam>
+    /// <returns>An instance of the form, asynchronously.</returns>
+    Task<T> GetFormAsync<T>() where T : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with a single constructor parameter on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameter while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1>(T1 param1) where TForm : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with two constructor parameters on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1, T2>(T1 param1, T2 param2) where TForm : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with three constructor parameters on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1, T2, T3>(T1 param1, T2 param2, T3 param3) where TForm : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with four constructor parameters on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4>(T1 param1, T2 param2, T3 param3, T4 param4) where TForm : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with five constructor parameters on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5) where TForm : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with six constructor parameters on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <typeparam name="T6">The type of the sixth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <param name="param6">The sixth parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6) where TForm : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with seven constructor parameters on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <typeparam name="T6">The type of the sixth constructor parameter.</typeparam>
+    /// <typeparam name="T7">The type of the seventh constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <param name="param6">The sixth parameter to pass to the form constructor.</param>
+    /// <param name="param7">The seventh parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7) where TForm : Form;
+
+    /// <summary>
+    /// Asynchronously creates a form instance with eight constructor parameters on the UI thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <typeparam name="T6">The type of the sixth constructor parameter.</typeparam>
+    /// <typeparam name="T7">The type of the seventh constructor parameter.</typeparam>
+    /// <typeparam name="T8">The type of the eighth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <param name="param6">The sixth parameter to pass to the form constructor.</param>
+    /// <param name="param7">The seventh parameter to pass to the form constructor.</param>
+    /// <param name="param8">The eighth parameter to pass to the form constructor.</param>
+    /// <returns>A task containing the created form instance.</returns>
+    /// <remarks>
+    /// This method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/> to create the form
+    /// with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the form type cannot be instantiated or when the UI thread is not available.
+    /// </exception>
+    Task<TForm> GetFormAsync<TForm, T1, T2, T3, T4, T5, T6, T7, T8>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8) where TForm : Form;
+
+    /// <summary>
+    /// Gets the requested form type and ensures it is created on the UI thread. Creates the form in the given scope.
+    /// </summary>
+    /// <typeparam name="T">The form type to get.</typeparam>
+    /// <param name="scope">The scope in which the form should be created.</param>
+    /// <returns>An instance of the form, asynchronously.</returns>
+    Task<T> GetFormAsync<T>(IServiceScope scope) where T : Form;
+
+    Task<Form> GetMainFormAsync();
+
+    /// <summary>
+    /// Gets the requested form type on the current thread. Should only be called on the UI thread. All scoped and transient dependencies will be disposed when the form is disposed.
+    /// </summary>
+    /// <typeparam name="T">The form type to get.</typeparam>
+    /// <returns>An instance of the form.</returns>
+    T GetForm<T>() where T : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with a single constructor parameter on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameter while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1>(T1 param1) where TForm : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with two constructor parameters on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1, T2>(T1 param1, T2 param2) where TForm : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with three constructor parameters on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1, T2, T3>(T1 param1, T2 param2, T3 param3) where TForm : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with four constructor parameters on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1, T2, T3, T4>(T1 param1, T2 param2, T3 param3, T4 param4) where TForm : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with five constructor parameters on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1, T2, T3, T4, T5>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5) where TForm : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with six constructor parameters on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <typeparam name="T6">The type of the sixth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <param name="param6">The sixth parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1, T2, T3, T4, T5, T6>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6) where TForm : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with seven constructor parameters on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <typeparam name="T6">The type of the sixth constructor parameter.</typeparam>
+    /// <typeparam name="T7">The type of the seventh constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <param name="param6">The sixth parameter to pass to the form constructor.</param>
+    /// <param name="param7">The seventh parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1, T2, T3, T4, T5, T6, T7>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7) where TForm : Form;
+
+    /// <summary>
+    /// Synchronously creates a form instance with eight constructor parameters on the current thread.
+    /// </summary>
+    /// <typeparam name="TForm">The form type to create.</typeparam>
+    /// <typeparam name="T1">The type of the first constructor parameter.</typeparam>
+    /// <typeparam name="T2">The type of the second constructor parameter.</typeparam>
+    /// <typeparam name="T3">The type of the third constructor parameter.</typeparam>
+    /// <typeparam name="T4">The type of the fourth constructor parameter.</typeparam>
+    /// <typeparam name="T5">The type of the fifth constructor parameter.</typeparam>
+    /// <typeparam name="T6">The type of the sixth constructor parameter.</typeparam>
+    /// <typeparam name="T7">The type of the seventh constructor parameter.</typeparam>
+    /// <typeparam name="T8">The type of the eighth constructor parameter.</typeparam>
+    /// <param name="param1">The first parameter to pass to the form constructor.</param>
+    /// <param name="param2">The second parameter to pass to the form constructor.</param>
+    /// <param name="param3">The third parameter to pass to the form constructor.</param>
+    /// <param name="param4">The fourth parameter to pass to the form constructor.</param>
+    /// <param name="param5">The fifth parameter to pass to the form constructor.</param>
+    /// <param name="param6">The sixth parameter to pass to the form constructor.</param>
+    /// <param name="param7">The seventh parameter to pass to the form constructor.</param>
+    /// <param name="param8">The eighth parameter to pass to the form constructor.</param>
+    /// <returns>The created form instance.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method should only be called from the UI thread. It creates a new service scope for the form
+    /// and automatically disposes it when the form is disposed. The method uses <see cref="ActivatorUtilities.CreateInstance{T}(IServiceProvider, object[])"/>
+    /// to create the form with the provided parameters while resolving other dependencies from the dependency injection container.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called from a non-UI thread or when the form type cannot be instantiated.
+    /// </exception>
+    TForm GetForm<TForm, T1, T2, T3, T4, T5, T6, T7, T8>(T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6, T7 param7, T8 param8) where TForm : Form;
+
+    /// <summary>
+    /// Gets the requested form type on the current thread. Should only be called on the UI thread.  Creates the form in the given scope.
+    /// </summary>
+    /// <typeparam name="T">The form type to get.</typeparam>
+    /// <param name="scope">The scope in which the form should be created.</param>
+    /// <returns>An instance of the form.</returns>
+    T GetForm<T>(IServiceScope scope) where T : Form;
+}

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -5,7 +5,7 @@
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
-		<Version>1.2.0</Version>
+		<Version>2.0.0</Version>
 		<Authors>Alex Oswald</Authors>
 		<Company>Oswald Technologies, LLC</Company>
 		<Description>.NET Core hosting infrastructure for Windows Forms.</Description>

--- a/tests/WindowsFormsLifetime.Tests/FormProviderTests.cs
+++ b/tests/WindowsFormsLifetime.Tests/FormProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Windows.Forms;
 using WindowsFormsLifetime;
@@ -79,6 +79,73 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public TransientDependency TransientDependency { get; init; } = transientDependency;
+
+        protected override void SetVisibleCore(bool value)
+        {
+            // Don't flash window when running unit tests
+            base.SetVisibleCore(false);
+
+            if (!IsHandleCreated)
+            {
+                CreateHandle();
+                OnLoad(EventArgs.Empty);
+            }
+        }
+    }
+
+    // New form types for parameterized async creation
+    public class TestFormWithOneParam(
+        ScopedDependency scopedDependency,
+        SingletonDependency singletonDependency,
+        TransientDependency transientDependency,
+        string title) : Form
+    {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ScopedDependency ScopedDependency { get; init; } = scopedDependency;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public SingletonDependency SingletonDependency { get; init; } = singletonDependency;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public TransientDependency TransientDependency { get; init; } = transientDependency;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public string Title { get; init; } = title;
+
+        protected override void SetVisibleCore(bool value)
+        {
+            // Don't flash window when running unit tests
+            base.SetVisibleCore(false);
+
+            if (!IsHandleCreated)
+            {
+                CreateHandle();
+                OnLoad(EventArgs.Empty);
+            }
+        }
+    }
+
+    public class TestFormWithTwoParams(
+        ScopedDependency scopedDependency,
+        SingletonDependency singletonDependency,
+        TransientDependency transientDependency,
+        string title,
+        int count) : Form
+    {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public ScopedDependency ScopedDependency { get; init; } = scopedDependency;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public SingletonDependency SingletonDependency { get; init; } = singletonDependency;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public TransientDependency TransientDependency { get; init; } = transientDependency;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public string Title { get; init; } = title;
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int Count { get; init; } = count;
 
         protected override void SetVisibleCore(bool value)
         {
@@ -285,5 +352,73 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         Assert.True(transientDep.IsDisposed, "TransientDependency is not disposed, but should be disposed.");
 
         Assert.False(singletonDep.IsDisposed, "SingletonDependency is disposed, but should not be disposed.");
+    }
+
+    [Fact]
+    public async Task GetFormAsync_With_One_Parameter_Constructs_And_Disposes_Dependencies()
+    {
+        // Arrange
+        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+        var expectedTitle = "Hello Async One Param";
+
+        ScopedDependency? scopedDep = null;
+        SingletonDependency? singletonDep = null;
+        TransientDependency? transientDep = null;
+
+        // Act
+        using (var form = await provider.GetFormAsync<TestFormWithOneParam, string>(expectedTitle))
+        {
+            // Assert
+            Assert.NotNull(form);
+            Assert.Equal(expectedTitle, form.Title);
+
+            scopedDep = form.ScopedDependency;
+            singletonDep = form.SingletonDependency;
+            transientDep = form.TransientDependency;
+
+            Assert.False(scopedDep.IsDisposed);
+            Assert.False(singletonDep.IsDisposed);
+            Assert.False(transientDep.IsDisposed);
+        }
+
+        // Assert disposal after form disposed
+        Assert.True(scopedDep!.IsDisposed);
+        Assert.True(transientDep!.IsDisposed);
+        Assert.False(singletonDep!.IsDisposed);
+    }
+
+    [Fact]
+    public async Task GetFormAsync_With_Two_Parameters_Constructs_And_Disposes_Dependencies()
+    {
+        // Arrange
+        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+        var expectedTitle = "Hello Async Two Params";
+        var expectedCount = 42;
+
+        ScopedDependency? scopedDep = null;
+        SingletonDependency? singletonDep = null;
+        TransientDependency? transientDep = null;
+
+        // Act
+        using (var form = await provider.GetFormAsync<TestFormWithTwoParams, string, int>(expectedTitle, expectedCount))
+        {
+            // Assert
+            Assert.NotNull(form);
+            Assert.Equal(expectedTitle, form.Title);
+            Assert.Equal(expectedCount, form.Count);
+
+            scopedDep = form.ScopedDependency;
+            singletonDep = form.SingletonDependency;
+            transientDep = form.TransientDependency;
+
+            Assert.False(scopedDep.IsDisposed);
+            Assert.False(singletonDep.IsDisposed);
+            Assert.False(transientDep.IsDisposed);
+        }
+
+        // Assert disposal after form disposed
+        Assert.True(scopedDep!.IsDisposed);
+        Assert.True(transientDep!.IsDisposed);
+        Assert.False(singletonDep!.IsDisposed);
     }
 }

--- a/tests/WindowsFormsLifetime.Tests/FormProviderTests.cs
+++ b/tests/WindowsFormsLifetime.Tests/FormProviderTests.cs
@@ -13,6 +13,9 @@ namespace WindowsFormsLifetimeTests;
 public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixture<FormProviderTests.HostFixture>
 {
     private readonly HostFixture _host = host;
+    private static readonly string[] ParameterValues = ["one", "two", "three", "four", "five", "six", "seven", "eight"];
+
+    private IGuiContext GuiContext => _host.Host.Services.GetRequiredService<IGuiContext>();
 
     public class HostFixture : IDisposable
     {
@@ -30,6 +33,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
                     services.AddSingleton<SingletonDependency>();
                     services.AddTransient<TransientDependency>();
                     services.AddTransient<TestFormWithDependencies>();
+                    services.AddTransient<ThrowingForm>(_ => throw new InvalidOperationException("Expected form creation failure."));
                 });
             Host = hostBuilder.Build();
 
@@ -93,12 +97,18 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         }
     }
 
-    // New form types for parameterized async creation
-    public class TestFormWithOneParam(
+    public class TestFormWithParameters(
         ScopedDependency scopedDependency,
         SingletonDependency singletonDependency,
         TransientDependency transientDependency,
-        string title) : Form
+        string parameter1,
+        string? parameter2 = null,
+        string? parameter3 = null,
+        string? parameter4 = null,
+        string? parameter5 = null,
+        string? parameter6 = null,
+        string? parameter7 = null,
+        string? parameter8 = null) : Form
     {
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public ScopedDependency ScopedDependency { get; init; } = scopedDependency;
@@ -109,8 +119,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public TransientDependency TransientDependency { get; init; } = transientDependency;
 
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string Title { get; init; } = title;
+        public string?[] Parameters { get; } = [parameter1, parameter2, parameter3, parameter4, parameter5, parameter6, parameter7, parameter8];
 
         protected override void SetVisibleCore(bool value)
         {
@@ -125,39 +134,8 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         }
     }
 
-    public class TestFormWithTwoParams(
-        ScopedDependency scopedDependency,
-        SingletonDependency singletonDependency,
-        TransientDependency transientDependency,
-        string title,
-        int count) : Form
+    public class ThrowingForm : Form
     {
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public ScopedDependency ScopedDependency { get; init; } = scopedDependency;
-
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public SingletonDependency SingletonDependency { get; init; } = singletonDependency;
-
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public TransientDependency TransientDependency { get; init; } = transientDependency;
-
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string Title { get; init; } = title;
-
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int Count { get; init; } = count;
-
-        protected override void SetVisibleCore(bool value)
-        {
-            // Don't flash window when running unit tests
-            base.SetVisibleCore(false);
-
-            if (!IsHandleCreated)
-            {
-                CreateHandle();
-                OnLoad(EventArgs.Empty);
-            }
-        }
     }
 
     [Fact]
@@ -194,7 +172,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         ScopedDependency? scopedDep = null;
         SingletonDependency? singletonDep = null;
         TransientDependency? transientDep = null;
-        using (var form = _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>())
+        using (var form = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>()))
         {
             Assert.NotNull(form);
 
@@ -252,7 +230,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         TransientDependency? transientDep = null;
         using (var scope = _host.Host.Services.GetRequiredService<IServiceScopeFactory>().CreateScope())
         {
-            using (var form = _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope))
+            using (var form = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope)))
             {
                 Assert.NotNull(form);
 
@@ -265,7 +243,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
                 transientDep = form.TransientDependency;
                 Assert.False(transientDep.IsDisposed, "TransientDependency is disposed, but should not be disposed.");
 
-                using (var form2 = _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope))
+                using (var form2 = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope)))
                 {
                     Assert.NotNull(form2);
 
@@ -355,70 +333,114 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
     }
 
     [Fact]
-    public async Task GetFormAsync_With_One_Parameter_Constructs_And_Disposes_Dependencies()
+    public void GetForm_With_One_To_Eight_Parameters_Constructs_And_Disposes_Dependencies()
     {
-        // Arrange
         var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
-        var expectedTitle = "Hello Async One Param";
 
-        ScopedDependency? scopedDep = null;
-        SingletonDependency? singletonDep = null;
-        TransientDependency? transientDep = null;
-
-        // Act
-        using (var form = await provider.GetFormAsync<TestFormWithOneParam, string>(expectedTitle))
-        {
-            // Assert
-            Assert.NotNull(form);
-            Assert.Equal(expectedTitle, form.Title);
-
-            scopedDep = form.ScopedDependency;
-            singletonDep = form.SingletonDependency;
-            transientDep = form.TransientDependency;
-
-            Assert.False(scopedDep.IsDisposed);
-            Assert.False(singletonDep.IsDisposed);
-            Assert.False(transientDep.IsDisposed);
-        }
-
-        // Assert disposal after form disposed
-        Assert.True(scopedDep!.IsDisposed);
-        Assert.True(transientDep!.IsDisposed);
-        Assert.False(singletonDep!.IsDisposed);
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string>(ParameterValues[0])),
+            GetExpectedParameters(1));
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string, string>(ParameterValues[0], ParameterValues[1])),
+            GetExpectedParameters(2));
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2])),
+            GetExpectedParameters(3));
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3])),
+            GetExpectedParameters(4));
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4])),
+            GetExpectedParameters(5));
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4], ParameterValues[5])),
+            GetExpectedParameters(6));
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string, string, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4], ParameterValues[5], ParameterValues[6])),
+            GetExpectedParameters(7));
+        AssertParameterizedForm(
+            GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string, string, string, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4], ParameterValues[5], ParameterValues[6], ParameterValues[7])),
+            GetExpectedParameters(8));
     }
 
     [Fact]
-    public async Task GetFormAsync_With_Two_Parameters_Constructs_And_Disposes_Dependencies()
+    public async Task GetFormAsync_With_One_To_Eight_Parameters_Constructs_And_Disposes_Dependencies()
     {
-        // Arrange
         var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
-        var expectedTitle = "Hello Async Two Params";
-        var expectedCount = 42;
 
-        ScopedDependency? scopedDep = null;
-        SingletonDependency? singletonDep = null;
-        TransientDependency? transientDep = null;
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string>(ParameterValues[0]),
+            GetExpectedParameters(1));
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string, string>(ParameterValues[0], ParameterValues[1]),
+            GetExpectedParameters(2));
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2]),
+            GetExpectedParameters(3));
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3]),
+            GetExpectedParameters(4));
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4]),
+            GetExpectedParameters(5));
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4], ParameterValues[5]),
+            GetExpectedParameters(6));
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string, string, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4], ParameterValues[5], ParameterValues[6]),
+            GetExpectedParameters(7));
+        AssertParameterizedForm(
+            await provider.GetFormAsync<TestFormWithParameters, string, string, string, string, string, string, string, string>(ParameterValues[0], ParameterValues[1], ParameterValues[2], ParameterValues[3], ParameterValues[4], ParameterValues[5], ParameterValues[6], ParameterValues[7]),
+            GetExpectedParameters(8));
+    }
 
-        // Act
-        using (var form = await provider.GetFormAsync<TestFormWithTwoParams, string, int>(expectedTitle, expectedCount))
+    [Fact]
+    public async Task GetForm_With_Parameters_Outside_Ui_Thread_Throws()
+    {
+        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Task.Run(() => provider.GetForm<TestFormWithParameters, string>(ParameterValues[0])));
+    }
+
+    [Fact]
+    public async Task GetFormAsync_Releases_Semaphore_After_Creation_Failure()
+    {
+        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetFormAsync<ThrowingForm>());
+
+        var succeedingRequest = provider.GetFormAsync<TestFormWithDependencies>();
+        var completedRequest = await Task.WhenAny(succeedingRequest, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.Same(succeedingRequest, completedRequest);
+
+        using var form = await succeedingRequest;
+        Assert.NotNull(form);
+    }
+
+    private static string[] GetExpectedParameters(int count) => ParameterValues[..count];
+
+    private static void AssertParameterizedForm(TestFormWithParameters form, params string[] expectedParameters)
+    {
+        using (form)
         {
-            // Assert
-            Assert.NotNull(form);
-            Assert.Equal(expectedTitle, form.Title);
-            Assert.Equal(expectedCount, form.Count);
+            for (var index = 0; index < expectedParameters.Length; index++)
+            {
+                Assert.Equal(expectedParameters[index], form.Parameters[index]);
+            }
 
-            scopedDep = form.ScopedDependency;
-            singletonDep = form.SingletonDependency;
-            transientDep = form.TransientDependency;
+            for (var index = expectedParameters.Length; index < form.Parameters.Length; index++)
+            {
+                Assert.Null(form.Parameters[index]);
+            }
 
-            Assert.False(scopedDep.IsDisposed);
-            Assert.False(singletonDep.IsDisposed);
-            Assert.False(transientDep.IsDisposed);
+            Assert.False(form.ScopedDependency.IsDisposed);
+            Assert.False(form.SingletonDependency.IsDisposed);
+            Assert.False(form.TransientDependency.IsDisposed);
         }
 
-        // Assert disposal after form disposed
-        Assert.True(scopedDep!.IsDisposed);
-        Assert.True(transientDep!.IsDisposed);
-        Assert.False(singletonDep!.IsDisposed);
+        Assert.True(form.ScopedDependency.IsDisposed);
+        Assert.True(form.TransientDependency.IsDisposed);
+        Assert.False(form.SingletonDependency.IsDisposed);
     }
 }


### PR DESCRIPTION
Moved the `IFormProvider` interface to separate file.

Refactored the `IFormProvider` interface to support creating forms with up to eight constructor parameters, both synchronously and asynchronously, using `ActivatorUtilities.CreateInstance`.

Added new test forms (`TestFormWithOneParam`, `TestFormWithTwoParams`) and unit tests to validate the behavior of the new methods.