### PR TITLE
Add .NET 10 support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+# WindowsFormsLifetime Copilot Instructions
+
+## Scope and compatibility
+
+- Treat `src/WindowsFormsLifetime` as the published library. Keep its supported target frameworks as `net8.0-windows`, `net9.0-windows`, and `net10.0-windows`.
+- Keep each target framework's `Microsoft.Extensions.Hosting` reference in its matching conditional `ItemGroup`.
+- Do not change the package `<Version>` unless the user explicitly asks to prepare a release or bump the package version.
+- Preserve the public API surface unless the requested change requires an intentional API addition or breaking change.
+
+## Preserve the existing style
+
+- Make surgical edits. Do not reformat unrelated code, reorder existing `using` directives, normalize whitespace, or change a file's established tabs-versus-spaces indentation.
+- Follow the local C# style: file-scoped namespaces, PascalCase public members, camelCase parameters, underscore-prefixed private fields, braces for multi-statement blocks, and expression-bodied members only for simple forwarding logic.
+- Continue using XML documentation for public APIs where the surrounding code documents them. Match the existing concise summaries and parameter descriptions.
+- Keep project XML grouped and indented like the file being edited. Do not move unrelated properties or package references.
+
+## Windows Forms and hosting behavior
+
+- Preserve the UI-thread boundary. Create and interact with forms through the synchronization-context and form-provider abstractions rather than bypassing them from background services.
+- Preserve DI lifetimes and disposal behavior when adding forms, hosted services, or registrations.
+- Add or update xUnit tests for behavior changes. Keep host-related tests in the existing non-parallel collection when they exercise the Windows Forms lifetime.
+
+## Dependencies and validation
+
+- Prefer framework-compatible, stable package versions. Update only the dependencies needed for the requested change and account for API changes in samples and tests.
+- Build the solution and run the targeted test project after code or project-file changes.

--- a/TestWindowsFormsLifetime.yml
+++ b/TestWindowsFormsLifetime.yml
@@ -15,9 +15,9 @@ variables:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET 9.x SDK'
+  displayName: 'Use .NET 10.x SDK'
   inputs:
-    version: 9.x
+    version: 10.x
 
 - task: DotNetCoreCLI@2
   displayName: 'Restore Solution'

--- a/samples/AppContext/AppContext.csproj
+++ b/samples/AppContext/AppContext.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<UseWindowsForms>true</UseWindowsForms>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>

--- a/samples/BlazorHybrid/BlazorHybrid.csproj
+++ b/samples/BlazorHybrid/BlazorHybrid.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -10,8 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="9.0.40" />
-    <PackageReference Include="MudBlazor" Version="8.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="10.0.90" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
+    <PackageReference Include="MudBlazor" Version="9.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<UseWindowsForms>true</UseWindowsForms>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -5,7 +5,7 @@
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
-		<Version>1.3.0</Version>
+		<Version>1.2.0</Version>
 		<Authors>Alex Oswald</Authors>
 		<Company>Oswald Technologies, LLC</Company>
 		<Description>.NET Core hosting infrastructure for Windows Forms.</Description>

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks>net9.0-windows;net10.0-windows</TargetFrameworks>
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
-		<Version>1.2.0</Version>
+		<Version>1.3.0</Version>
 		<Authors>Alex Oswald</Authors>
 		<Company>Oswald Technologies, LLC</Company>
 		<Description>.NET Core hosting infrastructure for Windows Forms.</Description>
@@ -32,18 +32,18 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.18" />
 	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+	</ItemGroup>
 
 </Project>

--- a/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
+++ b/src/WindowsFormsLifetime/WindowsFormsLifetime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-windows;net10.0-windows</TargetFrameworks>
+		<TargetFrameworks>net8.0-windows;net9.0-windows;net10.0-windows</TargetFrameworks>
 		<Nullable>disable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PackageId>OswaldTechnologies.Extensions.Hosting.WindowsFormsLifetime</PackageId>
@@ -36,6 +36,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows'">

--- a/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.csproj
+++ b/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary

Add .NET 10 support while keeping WindowsFormsLifetime compatible with .NET 8 and .NET 9, without preparing a package release yet.

- Target the library for `net8.0-windows`, `net9.0-windows`, and `net10.0-windows`, with matching Hosting dependencies for each framework.
- Move the tests, samples, and Azure pipeline to .NET 10, and refresh SourceLink, test tooling, and Blazor-related dependencies.
- Add repository-specific Copilot instructions to preserve the current C#, project-file, test, and release conventions.
- Keep the package version at `1.2.0` until a release version is explicitly requested.