### PR TITLE
Use explicit types for local variables

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.cs]
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = false:warning
+csharp_style_var_elsewhere = false:warning

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@
 
 - Make surgical edits. Do not reformat unrelated code, reorder existing `using` directives, normalize whitespace, or change a file's established tabs-versus-spaces indentation.
 - Follow the local C# style: file-scoped namespaces, PascalCase public members, camelCase parameters, underscore-prefixed private fields, braces for multi-statement blocks, and expression-bodied members only for simple forwarding logic.
+- Use explicit types for local variables; do not use `var`.
 - Continue using XML documentation for public APIs where the surrounding code documents them. Match the existing concise summaries and parameter descriptions.
 - Keep project XML grouped and indented like the file being edited. Do not move unrelated properties or package references.
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ using Microsoft.Extensions.Hosting;
 using WinFormsApp1;
 using WindowsFormsLifetime;
 
-var builder = Host.CreateApplicationBuilder(args);
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 builder.UseWindowsFormsLifetime<Form1>();
 
-var app = builder.Build();
+IHost app = builder.Build();
 app.Run();
 ```
 
@@ -72,10 +72,10 @@ Allows the use of Ctrl+C to shutdown the host while the console is being used.
 Add more forms to the DI container.
 
 ```csharp
-var builder = Host.CreateApplicationBuilder(args);
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 builder.UseWindowsFormsLifetime<Form1>();
 builder.Services.AddTransient<Form2>();
-var app = builder.Build();
+IHost app = builder.Build();
 app.Run();
 ```
 
@@ -102,7 +102,7 @@ public partial class Form1 : Form
     private async void button1_Click(object sender, EventArgs e)
     {
         _logger.LogInformation("Show Form2");
-        var form = await _formProvider.GetFormAsync<Form2>();
+        Form2 form = await _formProvider.GetFormAsync<Form2>();
         form.Show();
     }
 }
@@ -143,7 +143,7 @@ public class HostedService1 : BackgroundService
             {
                 await _guiContext.InvokeAsync(async () =>
                 {
-                    var form = await _fp.GetFormAsync<Form2>();
+                    Form2 form = await _fp.GetFormAsync<Form2>();
                     form.Show();
                 });
             }

--- a/samples/AppContext/Program.cs
+++ b/samples/AppContext/Program.cs
@@ -1,10 +1,10 @@
 ﻿using AppContext;
 using WindowsFormsLifetime;
 
-var builder = WebApplication.CreateBuilder(args);
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 // Pass in a factory lambda that constructs an ApplicationContext using the start form
 builder.Host.UseWindowsFormsLifetime<ExampleApplicationContext, HiddenForm>(
     startForm => new ExampleApplicationContext(startForm));
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 app.Run();

--- a/samples/BlazorHybrid/Program.cs
+++ b/samples/BlazorHybrid/Program.cs
@@ -2,10 +2,10 @@ using BlazorHybrid;
 using MudBlazor.Services;
 using WindowsFormsLifetime;
 
-var builder = WebApplication.CreateBuilder(args);
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.Host.UseWindowsFormsLifetime<Form1>();
 builder.Services.AddWindowsFormsBlazorWebView();
 builder.Services.AddMudServices();
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 app.Run();

--- a/samples/SampleApp/Form1.cs
+++ b/samples/SampleApp/Form1.cs
@@ -30,7 +30,7 @@ public partial class Form1 : Form
     private async void button1_Click(object sender, EventArgs e)
     {
         _logger.LogInformation("Show");
-        var form = await _formProvider.GetFormAsync<Form2>();
+        Form2 form = await _formProvider.GetFormAsync<Form2>();
         form.Show();
     }
 

--- a/samples/SampleApp/FormSpawnHostedService.cs
+++ b/samples/SampleApp/FormSpawnHostedService.cs
@@ -32,7 +32,7 @@ public class FormSpawnHostedService : BackgroundService
                 // The form provider will get the form from the DI container on the gui thread
                 // Then we must invoke the Show method on the gui thread as well using IGuiContext
                 _logger.LogInformation($"GetFormAsync {Thread.CurrentThread.ManagedThreadId} {Thread.CurrentThread.Name}");
-                var form = await _fp.GetFormAsync<Form2>();
+                Form2 form = await _fp.GetFormAsync<Form2>();
                 _guiContext.Invoke(() => form.Show());
             }
             count++;

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -3,12 +3,12 @@ using Microsoft.Extensions.Hosting;
 using SampleApp;
 using WindowsFormsLifetime;
 
-var builder = Host.CreateApplicationBuilder(args);
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 builder.UseWindowsFormsLifetime<Form1>();
 builder.Services.AddHostedService<FormSpawnHostedService>();
 builder.Services.AddHostedService<TickingHostedService>();
 builder.Services.AddTransient<Form2>();
 builder.Services.AddSingleton<TickBag>();
 
-var app = builder.Build();
+IHost app = builder.Build();
 app.Run();

--- a/src/WindowsFormsLifetime/FormProvider.cs
+++ b/src/WindowsFormsLifetime/FormProvider.cs
@@ -60,7 +60,7 @@ public class FormProvider : IFormProvider
 
     public Task<Form> GetMainFormAsync()
     {
-        var applicationContext = _serviceProvider.GetService<ApplicationContext>();
+        ApplicationContext applicationContext = _serviceProvider.GetService<ApplicationContext>();
         return Task.FromResult(applicationContext.MainForm);
     }
 
@@ -69,7 +69,7 @@ public class FormProvider : IFormProvider
         EnsureUiThread();
 
         T form = null;
-        var scope = _serviceScopeFactory.CreateScope();
+        IServiceScope scope = _serviceScopeFactory.CreateScope();
         try
         {
             form = scope.ServiceProvider.GetService<T>();
@@ -140,7 +140,7 @@ public class FormProvider : IFormProvider
     private TForm CreateFormWithScope<TForm>(Func<IServiceScope, TForm> formFactory) where TForm : Form
     {
         TForm form;
-        var scope = _serviceScopeFactory.CreateScope();
+        IServiceScope scope = _serviceScopeFactory.CreateScope();
         try
         {
             form = formFactory(scope);
@@ -167,7 +167,7 @@ public class FormProvider : IFormProvider
 
     private async Task<T> InvokeOnUiThreadAsync<T>(Func<T> formFactory)
     {
-        var synchronizationContext = GetUiSynchronizationContext();
+        WindowsFormsSynchronizationContext synchronizationContext = GetUiSynchronizationContext();
         await _semaphore.WaitAsync();
 
         try
@@ -182,7 +182,7 @@ public class FormProvider : IFormProvider
 
     private void EnsureUiThread()
     {
-        var synchronizationContext = GetUiSynchronizationContext();
+        WindowsFormsSynchronizationContext synchronizationContext = GetUiSynchronizationContext();
         if (!ReferenceEquals(SynchronizationContext.Current, synchronizationContext))
         {
             throw new InvalidOperationException("Synchronous form creation must be called on the Windows Forms UI thread.");

--- a/src/WindowsFormsLifetime/ServiceCollectionExtensions.cs
+++ b/src/WindowsFormsLifetime/ServiceCollectionExtensions.cs
@@ -12,9 +12,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IHostLifetime, WindowsFormsLifetime>();
         services.AddHostedService(sp =>
         {
-            var options = sp.GetRequiredService<IOptions<WindowsFormsLifetimeOptions>>();
-            var life = sp.GetRequiredService<IHostApplicationLifetime>();
-            var sync = sp.GetRequiredService<WindowsFormsSynchronizationContextProvider>();
+            IOptions<WindowsFormsLifetimeOptions> options = sp.GetRequiredService<IOptions<WindowsFormsLifetimeOptions>>();
+            IHostApplicationLifetime life = sp.GetRequiredService<IHostApplicationLifetime>();
+            WindowsFormsSynchronizationContextProvider sync = sp.GetRequiredService<WindowsFormsSynchronizationContextProvider>();
             return new WindowsFormsHostedService(options, life, sp, sync, preApplicationRunAction);
         });
         services.Configure(configure ?? (_ => new WindowsFormsLifetimeOptions()));
@@ -113,7 +113,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<TStartForm>();
         services.AddSingleton<TAppContext>(provider =>
         {
-            var startForm = provider.GetRequiredService<TStartForm>();
+            TStartForm startForm = provider.GetRequiredService<TStartForm>();
             return applicationContextFactory(startForm);
         });
         services.AddSingleton<ApplicationContext>(provider => provider.GetRequiredService<TAppContext>());

--- a/src/WindowsFormsLifetime/SynchronizationContextExtensions.cs
+++ b/src/WindowsFormsLifetime/SynchronizationContextExtensions.cs
@@ -21,7 +21,7 @@ internal static class SynchronizationContextExtensions
 
     public static Task<TResult> InvokeAsync<TResult>(this SynchronizationContext context, Func<TResult> func)
     {
-        var tcs = new TaskCompletionSource<TResult>();
+        TaskCompletionSource<TResult> tcs = new();
         context.Post(delegate {
             try
             {
@@ -38,7 +38,7 @@ internal static class SynchronizationContextExtensions
 
     public static Task<TResult> InvokeAsync<TResult, TInput>(this SynchronizationContext context, Func<TInput, TResult> func, TInput input)
     {
-        var tcs = new TaskCompletionSource<TResult>();
+        TaskCompletionSource<TResult> tcs = new();
         context.Post(delegate {
             try
             {

--- a/src/WindowsFormsLifetime/WindowsFormsHostedService.cs
+++ b/src/WindowsFormsLifetime/WindowsFormsHostedService.cs
@@ -79,7 +79,7 @@ public class WindowsFormsHostedService : IHostedService, IDisposable
                 _threadExceptionHandlerAttached = true;
             }
 
-            var applicationContext = _serviceProvider.GetService<ApplicationContext>();
+            ApplicationContext applicationContext = _serviceProvider.GetService<ApplicationContext>();
             PreApplicationRunAction?.Invoke(_serviceProvider);
             Application.Run(applicationContext);
         }
@@ -96,8 +96,8 @@ public class WindowsFormsHostedService : IHostedService, IDisposable
 
     private void OnApplicationStopping()
     {
-        var applicationContext = _serviceProvider.GetService<ApplicationContext>();
-        var form = applicationContext.MainForm;
+        ApplicationContext applicationContext = _serviceProvider.GetService<ApplicationContext>();
+        Form form = applicationContext.MainForm;
 
         // If the form is closed then the handle no longer exists
         // We would get an exception trying to invoke from the control when it is already closed

--- a/tests/WindowsFormsLifetime.Tests/FormProviderTests.cs
+++ b/tests/WindowsFormsLifetime.Tests/FormProviderTests.cs
@@ -25,7 +25,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
 
         public HostFixture()
         {
-            var hostBuilder = new HostBuilder()
+            IHostBuilder hostBuilder = new HostBuilder()
                 .UseWindowsFormsLifetime<WindowsFormsLifetimeTests.TestForm>()
                 .ConfigureServices(services =>
                 {
@@ -144,7 +144,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         ScopedDependency? scopedDep = null;
         SingletonDependency? singletonDep = null;
         TransientDependency? transientDep = null;
-        using (var form = _host.Host.Services.GetService<TestFormWithDependencies>())
+        using (TestFormWithDependencies? form = _host.Host.Services.GetService<TestFormWithDependencies>())
         {
             Assert.NotNull(form);
 
@@ -172,7 +172,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         ScopedDependency? scopedDep = null;
         SingletonDependency? singletonDep = null;
         TransientDependency? transientDep = null;
-        using (var form = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>()))
+        using (TestFormWithDependencies form = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>()))
         {
             Assert.NotNull(form);
 
@@ -200,7 +200,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         ScopedDependency? scopedDep = null;
         SingletonDependency? singletonDep = null;
         TransientDependency? transientDep = null;
-        using (var form = await _host.Host.Services.GetRequiredService<IFormProvider>().GetFormAsync<TestFormWithDependencies>())
+        using (TestFormWithDependencies form = await _host.Host.Services.GetRequiredService<IFormProvider>().GetFormAsync<TestFormWithDependencies>())
         {
             Assert.NotNull(form);
 
@@ -228,9 +228,9 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         ScopedDependency? scopedDep = null;
         SingletonDependency? singletonDep = null;
         TransientDependency? transientDep = null;
-        using (var scope = _host.Host.Services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        using (IServiceScope scope = _host.Host.Services.GetRequiredService<IServiceScopeFactory>().CreateScope())
         {
-            using (var form = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope)))
+            using (TestFormWithDependencies form = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope)))
             {
                 Assert.NotNull(form);
 
@@ -243,7 +243,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
                 transientDep = form.TransientDependency;
                 Assert.False(transientDep.IsDisposed, "TransientDependency is disposed, but should not be disposed.");
 
-                using (var form2 = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope)))
+                using (TestFormWithDependencies form2 = GuiContext.Invoke(() => _host.Host.Services.GetRequiredService<IFormProvider>().GetForm<TestFormWithDependencies>(scope)))
                 {
                     Assert.NotNull(form2);
 
@@ -283,9 +283,9 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
         ScopedDependency? scopedDep = null;
         SingletonDependency? singletonDep = null;
         TransientDependency? transientDep = null;
-        using (var scope = _host.Host.Services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+        using (IServiceScope scope = _host.Host.Services.GetRequiredService<IServiceScopeFactory>().CreateScope())
         {
-            using (var form = await _host.Host.Services.GetRequiredService<IFormProvider>().GetFormAsync<TestFormWithDependencies>(scope))
+            using (TestFormWithDependencies form = await _host.Host.Services.GetRequiredService<IFormProvider>().GetFormAsync<TestFormWithDependencies>(scope))
             {
                 Assert.NotNull(form);
 
@@ -298,7 +298,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
                 transientDep = form.TransientDependency;
                 Assert.False(transientDep.IsDisposed, "TransientDependency is disposed, but should not be disposed.");
 
-                using (var form2 = await _host.Host.Services.GetRequiredService<IFormProvider>().GetFormAsync<TestFormWithDependencies>(scope))
+                using (TestFormWithDependencies form2 = await _host.Host.Services.GetRequiredService<IFormProvider>().GetFormAsync<TestFormWithDependencies>(scope))
                 {
                     Assert.NotNull(form2);
 
@@ -335,7 +335,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
     [Fact]
     public void GetForm_With_One_To_Eight_Parameters_Constructs_And_Disposes_Dependencies()
     {
-        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+        IFormProvider provider = _host.Host.Services.GetRequiredService<IFormProvider>();
 
         AssertParameterizedForm(
             GuiContext.Invoke(() => provider.GetForm<TestFormWithParameters, string>(ParameterValues[0])),
@@ -366,7 +366,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
     [Fact]
     public async Task GetFormAsync_With_One_To_Eight_Parameters_Constructs_And_Disposes_Dependencies()
     {
-        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+        IFormProvider provider = _host.Host.Services.GetRequiredService<IFormProvider>();
 
         AssertParameterizedForm(
             await provider.GetFormAsync<TestFormWithParameters, string>(ParameterValues[0]),
@@ -397,7 +397,7 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
     [Fact]
     public async Task GetForm_With_Parameters_Outside_Ui_Thread_Throws()
     {
-        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+        IFormProvider provider = _host.Host.Services.GetRequiredService<IFormProvider>();
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => Task.Run(() => provider.GetForm<TestFormWithParameters, string>(ParameterValues[0])));
@@ -406,15 +406,15 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
     [Fact]
     public async Task GetFormAsync_Releases_Semaphore_After_Creation_Failure()
     {
-        var provider = _host.Host.Services.GetRequiredService<IFormProvider>();
+        IFormProvider provider = _host.Host.Services.GetRequiredService<IFormProvider>();
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => provider.GetFormAsync<ThrowingForm>());
 
-        var succeedingRequest = provider.GetFormAsync<TestFormWithDependencies>();
-        var completedRequest = await Task.WhenAny(succeedingRequest, Task.Delay(TimeSpan.FromSeconds(5)));
+        Task<TestFormWithDependencies> succeedingRequest = provider.GetFormAsync<TestFormWithDependencies>();
+        Task completedRequest = await Task.WhenAny(succeedingRequest, Task.Delay(TimeSpan.FromSeconds(5)));
         Assert.Same(succeedingRequest, completedRequest);
 
-        using var form = await succeedingRequest;
+        using TestFormWithDependencies form = await succeedingRequest;
         Assert.NotNull(form);
     }
 
@@ -424,12 +424,12 @@ public class FormProviderTests(FormProviderTests.HostFixture host) : IClassFixtu
     {
         using (form)
         {
-            for (var index = 0; index < expectedParameters.Length; index++)
+            for (int index = 0; index < expectedParameters.Length; index++)
             {
                 Assert.Equal(expectedParameters[index], form.Parameters[index]);
             }
 
-            for (var index = expectedParameters.Length; index < form.Parameters.Length; index++)
+            for (int index = expectedParameters.Length; index < form.Parameters.Length; index++)
             {
                 Assert.Null(form.Parameters[index]);
             }

--- a/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
+++ b/tests/WindowsFormsLifetime.Tests/WindowsFormsLifetimeTests.cs
@@ -32,7 +32,7 @@ public class WindowsFormsLifetimeTests
         public TestContext(Action<TestContext>? onStart = null)
         {
             // Let's invoke this after constructor has been run
-            var timer = new Timer { Interval = 1, Enabled = true };
+            Timer timer = new() { Interval = 1, Enabled = true };
             timer.Tick += (sender, args) =>
             {
                 timer.Enabled = false;
@@ -58,9 +58,9 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public void Services_Available_With_Form()
     {
-        var hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestForm>();
+        IHostBuilder hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestForm>();
 
-        using var host = hostBuilder.Build();
+        using IHost host = hostBuilder.Build();
 
         Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
         Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
@@ -72,14 +72,14 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public void Services_Available_With_ApplicationContext()
     {
-        var hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestContext>();
+        IHostBuilder hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestContext>();
 
-        using var host = hostBuilder.Build();
+        using IHost host = hostBuilder.Build();
 
         Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
         Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
-        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
-        var testContext = host.Services.GetRequiredService<TestContext>();
+        ApplicationContext applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        TestContext testContext = host.Services.GetRequiredService<TestContext>();
 
         Assert.Same(testContext, applicationContext);
         Assert.NotNull(host.Services.GetService<IFormProvider>());
@@ -89,14 +89,14 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public void Services_Available_With_ApplicationContext_Form()
     {
-        var hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestContext, TestForm>((form) => new TestContext());
+        IHostBuilder hostBuilder = new HostBuilder().UseWindowsFormsLifetime<TestContext, TestForm>((form) => new TestContext());
 
-        using var host = hostBuilder.Build();
+        using IHost host = hostBuilder.Build();
 
         Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
         Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
-        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
-        var testContext = host.Services.GetRequiredService<TestContext>();
+        ApplicationContext applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        TestContext testContext = host.Services.GetRequiredService<TestContext>();
 
         Assert.Same(testContext, applicationContext);
         Assert.NotNull(host.Services.GetService<TestForm>());
@@ -106,18 +106,18 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public void Services_Available_With_ApplicationContext_With_ServiceProvider()
     {
-        var dependency = new TestDependency();
-        var hostBuilder = new HostBuilder()
+        TestDependency dependency = new();
+        IHostBuilder hostBuilder = new HostBuilder()
             .ConfigureServices(services => services.AddSingleton<TestDependency>(dependency))
             .UseWindowsFormsLifetime<ServiceProviderTestContext>(
                 static provider => new(provider.GetRequiredService<TestDependency>()));
 
-        using var host = hostBuilder.Build();
+        using IHost host = hostBuilder.Build();
 
         Assert.IsType<WindowsFormsLifetime.WindowsFormsLifetime>(host.Services.GetService<IHostLifetime>());
         Assert.IsType<WindowsFormsHostedService>(host.Services.GetService<IHostedService>());
-        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
-        var testContext = host.Services.GetRequiredService<ServiceProviderTestContext>();
+        ApplicationContext applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        ServiceProviderTestContext testContext = host.Services.GetRequiredService<ServiceProviderTestContext>();
 
         Assert.Same(testContext, applicationContext);
         Assert.Same(dependency, testContext.Dependency);
@@ -128,19 +128,19 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public void Services_Available_With_ApplicationContext_With_ServiceProvider_On_HostApplicationBuilder()
     {
-        var dependency = new TestDependency();
-        var hostBuilder = Host.CreateApplicationBuilder();
+        TestDependency dependency = new();
+        HostApplicationBuilder hostBuilder = Host.CreateApplicationBuilder();
         hostBuilder.Services.AddSingleton<TestDependency>(dependency);
 
-        var returnedBuilder = hostBuilder.UseWindowsFormsLifetime<ServiceProviderTestContext>(
+        IHostApplicationBuilder returnedBuilder = hostBuilder.UseWindowsFormsLifetime<ServiceProviderTestContext>(
             static provider => new(provider.GetRequiredService<TestDependency>()));
 
         Assert.Same(hostBuilder, returnedBuilder);
 
-        using var host = hostBuilder.Build();
+        using IHost host = hostBuilder.Build();
 
-        var applicationContext = host.Services.GetRequiredService<ApplicationContext>();
-        var testContext = host.Services.GetRequiredService<ServiceProviderTestContext>();
+        ApplicationContext applicationContext = host.Services.GetRequiredService<ApplicationContext>();
+        ServiceProviderTestContext testContext = host.Services.GetRequiredService<ServiceProviderTestContext>();
 
         Assert.Same(testContext, applicationContext);
         Assert.Same(dependency, testContext.Dependency);
@@ -149,13 +149,13 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public void Services_Available_With_ApplicationContext_Without_Factory_From_ServiceCollection()
     {
-        var services = new ServiceCollection();
+        ServiceCollection services = new();
         services.AddWindowsFormsLifetime<TestContext>();
 
-        using var serviceProvider = services.BuildServiceProvider();
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
 
-        var applicationContext = serviceProvider.GetRequiredService<ApplicationContext>();
-        var testContext = serviceProvider.GetRequiredService<TestContext>();
+        ApplicationContext applicationContext = serviceProvider.GetRequiredService<ApplicationContext>();
+        TestContext testContext = serviceProvider.GetRequiredService<TestContext>();
 
         Assert.Same(testContext, applicationContext);
     }
@@ -163,9 +163,9 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public async Task Should_Run_And_Close_Form()
     {
-        using var host = new HostBuilder().UseWindowsFormsLifetime<TestForm>().Build();
+        using IHost host = new HostBuilder().UseWindowsFormsLifetime<TestForm>().Build();
 
-        var form = host.Services.GetService<TestForm>();
+        TestForm? form = host.Services.GetService<TestForm>();
         form!.Load += (sender, args) => form.Invoke(new Action(Application.Exit));
 
         await host.RunAsync();
@@ -176,10 +176,10 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public async Task Should_Run_And_Close_Form_When_Cancelling()
     {
-        using var host = new HostBuilder().UseWindowsFormsLifetime<TestForm>().Build();
-        using var cancelToken = new CancellationTokenSource();
+        using IHost host = new HostBuilder().UseWindowsFormsLifetime<TestForm>().Build();
+        using CancellationTokenSource cancelToken = new();
 
-        var form = host.Services.GetService<TestForm>();
+        TestForm? form = host.Services.GetService<TestForm>();
         form!.Load += (sender, args) => cancelToken.Cancel();
 
         await host.RunAsync(cancelToken.Token);
@@ -190,7 +190,7 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public async Task Should_Run_And_Close_ApplicationContext()
     {
-        using var host = new HostBuilder()
+        using IHost host = new HostBuilder()
             .UseWindowsFormsLifetime<TestContext>()
             .ConfigureServices(services => services.AddSingleton<Action<TestContext>>(context => Application.Exit()))
             .Build();
@@ -203,8 +203,8 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public async Task Should_Run_And_Close_ApplicationContext_When_Cancelling()
     {
-        using var cancelToken = new CancellationTokenSource();
-        using var host = new HostBuilder()
+        using CancellationTokenSource cancelToken = new();
+        using IHost host = new HostBuilder()
             .UseWindowsFormsLifetime<TestContext>()
             .ConfigureServices(services => services.AddSingleton<Action<TestContext>>(_ => cancelToken.Cancel()))
             .Build();
@@ -217,10 +217,10 @@ public class WindowsFormsLifetimeTests
     [Fact]
     public async Task Invokes_ThreadException_Handler()
     {
-        var expectedException = new InvalidOperationException();
-        var exceptionHandled = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        using var host = new HostBuilder()
+        InvalidOperationException expectedException = new();
+        TaskCompletionSource<Exception> exceptionHandled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        using CancellationTokenSource cancellationTokenSource = new(TimeSpan.FromSeconds(10));
+        using IHost host = new HostBuilder()
             .UseWindowsFormsLifetime<TestContext>(
                 configure: options => options.OnThreadException = exception =>
                 {
@@ -231,8 +231,8 @@ public class WindowsFormsLifetimeTests
                 new Action<TestContext>(_ => throw expectedException)))
             .Build();
 
-        var hostTask = host.RunAsync(cancellationTokenSource.Token);
-        var completedTask = await Task.WhenAny(
+        Task hostTask = host.RunAsync(cancellationTokenSource.Token);
+        Task completedTask = await Task.WhenAny(
             exceptionHandled.Task,
             hostTask,
             Task.Delay(TimeSpan.FromSeconds(10)));
@@ -243,7 +243,7 @@ public class WindowsFormsLifetimeTests
 
         Assert.Same(exceptionHandled.Task, completedTask);
 
-        var actualException = await exceptionHandled.Task;
+        Exception actualException = await exceptionHandled.Task;
         await hostTask.WaitAsync(TimeSpan.FromSeconds(10));
 
         Assert.Same(expectedException, actualException);


### PR DESCRIPTION
Use explicit local variable types consistently so declarations remain clear without relying on inference. This aligns the library, samples, tests, and documentation with the repository's style guidance.

- Add an `.editorconfig` rule that prefers explicit local types.
- Replace `var` declarations throughout the library, samples, and tests.
- Update the Copilot guidance and README examples.

No behavior changes are intended.